### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build image and publish
         # will be replace with own code later
-        uses: elgohr/Publish-Docker-Github-Action@2.11
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: devops-247114/deployers-test-container
           username: _json_key


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore